### PR TITLE
Updates and Fixes

### DIFF
--- a/R/report.R
+++ b/R/report.R
@@ -250,7 +250,7 @@ R <- plot_estimates(estimate = summarised_estimates[variable == "R"],
 if (!is.null(target_folder)) {
   suppressWarnings(
     suppressMessages(
-      ggplot2::ggsave(paste0(target_folder, "/reff_plot.png"),
+      ggplot2::ggsave(paste0(target_folder, "/R_plot.png"),
                       R,
                       width = 12,
                       height = 3,

--- a/tests/testthat/test-epinow.R
+++ b/tests/testthat/test-epinow.R
@@ -49,7 +49,7 @@ test_that("epinow produces expected output when run with default settings", {
   df_non_zero(out$estimated_reported_cases$samples)
   df_non_zero(out$estimated_reported_cases$summarised)
   df_non_zero(out$summary)
-  expect_equal(names(out$plots), c("infections", "reports", "reff", "growth_rate","summary"))
+  expect_equal(names(out$plots), c("infections", "reports", "R", "growth_rate","summary"))
 })
 
 test_that("epinow runs without error when saving to disk", {


### PR DESCRIPTION
* Update/rename the effective reproduction number:
Commit 66bf1a04c3e06e31a2cf3546f8723060f2d51ae6 renamed the effective reproduction number from `reff` to `R`.

This fixes:
```
test_check("EpiNow2")
── 1. Failure: epinow produces expected output when run with default settings (@
names(out$plots) not equal to c("infections", "reports", "reff", "growth_rate", "summary").
1/5 mismatches
x[3]: "R"
y[3]: "reff"
````